### PR TITLE
feat(climate): Add Zehnder manufacturer synonym

### DIFF
--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -565,12 +565,14 @@ async def test_climate_hvac_action_running_state_zehnder(
     ),
 )
 async def test_set_hvac_mode_zehnder(
-    device_climate_zehnder: Device,
     zha_gateway: Gateway,
     hvac_mode,
     sys_mode,
 ):
     """Test setting hvac mode."""
+    device_climate_zehnder = await device_climate_mock(
+        zha_gateway, CLIMATE_ZEHNDER, manuf=MANUF_ZEHNDER
+    )
 
     thrm_cluster = device_climate_zehnder.device.endpoints[1].thermostat
     entity: ThermostatEntity = get_entity(

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -591,7 +591,10 @@ class ZenWithinThermostat(Thermostat):
 
 @MULTI_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    manufacturers={"ZEHNDER GROUP VAUX ANDIGNY      "},
+    manufacturers={
+        "ZEHNDER GROUP VAUX ANDIGNY      ",
+        "ZEHNDER GROUP VAUX ANDIGNY"
+    },
     stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
 )
 class ZehnderThermostat(Thermostat):

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -591,10 +591,7 @@ class ZenWithinThermostat(Thermostat):
 
 @MULTI_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    manufacturers={
-        "ZEHNDER GROUP VAUX ANDIGNY      ",
-        "ZEHNDER GROUP VAUX ANDIGNY"
-    },
+    manufacturers={"ZEHNDER GROUP VAUX ANDIGNY      ", "ZEHNDER GROUP VAUX ANDIGNY"},
     stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
 )
 class ZehnderThermostat(Thermostat):


### PR DESCRIPTION
Hi,
I just saw your PR on the ZHA library, which is used by the integration on Home Assistant. I just bought an Acova heater.

I saw in your MR that you put as manufacturers `“ZEHNDER GROUP VAUX ANDIGNY      ”.` I assume that this is not a mistake and that it's your actual heater manufacturer. 

Personally, mine does not contain the ending spaces. Maybe it has a more recent version, and ZEHNDER fix this typo ? So I propose this PR.

I've just tested it and everything works.

Thanks to your contribution that allow me to control my heater :) 